### PR TITLE
Add Support For Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/sampathweb/pytorch-intro-workshop/master)
+
 # pytorch-intro-workshop
 
 Files for PyTorch Intro Tutorial at SF Python

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - pip:
     - pytorch-ignite
     - sklearn
+    - scipy

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,11 @@
+name: pytorch-intro-workshop
+channels:
+  - conda-forge
+dependencies:
+  - matplotlib
+  - numpy
+  - pytorch
+  - pandas
+  - pip:
+    - pytorch-ignite
+    - sklearn


### PR DESCRIPTION
Try out this branch [here](https://mybinder.org/v2/gh/rmorshea/pytorch-intro-workshop/binder).

Let me know if you have any questions or [read the docs](https://mybinder.readthedocs.io/).

The one limitation of mybinder.org is that it's a free service and wont necessarily support a large number of people using it at one time. So in a workshop setting you should definitely still plan to have people do a local install. At the very least though this provides an `environment.yml` file that can be used to `conda install` everything.